### PR TITLE
Configuration: drop hard-coded Linux-based distribution string

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,8 @@ const core = require('@actions/core');
 const tc = require('@actions/tool-cache');
 
 function z3URL(architecture, version) {
-    let distribution = "ubuntu-16.04";
     let path = "https://github.com/Z3Prover/z3/releases/download/z3-" + version;
-    let file = "z3-" + version + "-" + architecture + "-" + distribution + ".zip";
+    let file = "z3-" + version + "-" + architecture + ".zip";
     return { path: path, file: file };
 }
 


### PR DESCRIPTION
Due to your hard-coded Linux-based distribution string, your GitHub action does not work any longer for non Linux-based GitHub action runners like MacOS or Windows, see:

https://github.com/pavpanchekha/setup-z3/blob/7e911b623e2bcf99bb1e6df1eff60ca4c7a6ddba/index.js#L5-L7

I've analyzed the release strings at [1] and detected that mostly for Linux and MacOS based operating systems the architecture string does vary sometimes even inside a single Z3 release, which should be completly addressable by your two provided input variables `version` and `architecture` like `"z3-"version"-"architecture".zip"` (see the latest asset names for the Z3 ZIP files).
 
Therefore, I've dropped in this PR your hard-coded `distribution` in the `file` string concatenation, which can be directly adjusted and provided (if needed) by the GitHub action workflow YAML configuration file.

[1] https://github.com/Z3Prover/z3/releases

```
z3-4.8.10-x64-osx-10.15.7.zip
z3-4.8.10-x64-ubuntu-18.04.zip
z3-4.8.10-x64-win.zip
z3-4.8.10-x86-win.zip

z3-4.8.9-x64-osx-10.14.6.zip
z3-4.8.9-x64-ubuntu-16.04.zip
z3-4.8.9-x64-win.zip
z3-4.8.9-x86-win.zip

z3-4.8.8-x64-osx-10.14.6.zip
z3-4.8.8-x64-ubuntu-16.04.zip
z3-4.8.8-x64-win.zip
z3-4.8.8-x86-win.zip

z3-4.8.7-x64-osx-10.14.6.zip
z3-4.8.7-x64-ubuntu-16.04.zip
z3-4.8.7-x64-win.zip
z3-4.8.7-x86-win.zip

z3-4.8.6-x64-osx-10.14.6.zip
z3-4.8.6-x64-ubuntu-16.04.zip
z3-4.8.6-x64-win.zip
z3-4.8.6-x86-win.zip

z3-4.8.5-x64-debian-8.11.zip
z3-4.8.5-x64-osx-10.14.2.zip
z3-4.8.5-x64-ubuntu-14.04.zip
z3-4.8.5-x64-ubuntu-16.04.zip
z3-4.8.5-x64-win.zip
z3-4.8.5-x86-win.zip

z3-4.8.4.d6df51951f4c-x64-debian-8.11.zip
z3-4.8.4.d6df51951f4c-x64-osx-10.14.1.zip
z3-4.8.4.d6df51951f4c-x64-ubuntu-14.04.zip
z3-4.8.4.d6df51951f4c-x64-ubuntu-16.04.zip
z3-4.8.4.d6df51951f4c-x64-win.zip
z3-4.8.4.d6df51951f4c-x86-win.zip

z3-4.8.3.7f5d66c3c299-x64-debian-8.11.zip
z3-4.8.3.7f5d66c3c299-x64-osx-10.13.6.zip
z3-4.8.3.7f5d66c3c299-x64-ubuntu-14.04.zip
z3-4.8.3.7f5d66c3c299-x64-ubuntu-16.04.zip
z3-4.8.3.7f5d66c3c299-x64-win.zip
z3-4.8.3.7f5d66c3c299-x86-ubuntu-14.04.zip
z3-4.8.3.7f5d66c3c299-x86-win.zip

z3-4.8.1.016872a5e0f6-x64-debian-8.11.zip
z3-4.8.1.016872a5e0f6-x64-ubuntu-14.04.zip
z3-4.8.1.016872a5e0f6-x64-ubuntu-16.04.zip
z3-4.8.1.016872a5e0f6-x64-win.zip
z3-4.8.1.016872a5e0f6-x86-win.zip
z3-4.8.1.b301a59899ff-x64-osx-10.11.6.zip
z3-4.8.1.b301a59899ff-x86-ubuntu-14.04.zip

z3-4.7.1-x64-debian-8.10.zip
z3-4.7.1-x64-osx-10.11.6.zip
z3-4.7.1-x64-ubuntu-14.04.zip
z3-4.7.1-x64-ubuntu-16.04.zip
z3-4.7.1-x64-win.zip
z3-4.7.1-x86-ubuntu-14.04.zip
z3-4.7.1-x86-win.zip

z3-4.6.0-x64-debian-8.10.zip
z3-4.6.0-x64-osx-10.11.6.zip
z3-4.6.0-x64-ubuntu-14.04.zip
z3-4.6.0-x64-ubuntu-16.04.zip
z3-4.6.0-x64-win.zip
z3-4.6.0-x86-ubuntu-14.04.zip
z3-4.6.0-x86-win.zip

z3-4.5.0-x64-debian-8.5.zip
z3-4.5.0-x64-freebsd-10.2.zip
z3-4.5.0-x64-osx-10.11.6.zip
z3-4.5.0-x64-ubuntu-14.04.zip
z3-4.5.0-x64-win.zip
z3-4.5.0-x86-ubuntu-14.04.zip
z3-4.5.0-x86-win.zip

z3-4.4.1-x64-debian-8.2.zip
z3-4.4.1-x64-freebsd-10.2.zip
z3-4.4.1-x64-osx-10.11.zip
z3-4.4.1-x64-ubuntu-14.04.zip
z3-4.4.1-x64-win.zip
z3-4.4.1-x86-ubuntu-14.04.zip
z3-4.4.1-x86-win.zip

z3-4.4.0-x64-debian-7.8.zip
z3-4.4.0-x64-freebsd-10.1.zip
z3-4.4.0-x64-osx-10.10.3.zip
z3-4.4.0-x64-ubuntu-14.04.zip
z3-4.4.0-x64-win.zip
z3-4.4.0-x86-ubuntu-14.04.zip
z3-4.4.0-x86-win.zip

// ...
```

