### PR TITLE
use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     description: 'Version range or exact version of Z3 to use.'
     default: '4.10.2'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
This PR fixes the following warning:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: pavpanchekha/setup-z3@v0.3.0. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.