### PR TITLE
Export Z3_SYS_Z3_HEADER and LIBRARY_PATH

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ function z3URL(architecture, version, distribution) {
         const cachedPath = await tc.cacheDir(dir, 'z3', version);
         core.addPath(cachedPath + "/" + url.file.replace(/\.zip$/, "") + "/bin");
         core.exportVariable("CPATH", cachedPath + "/" + url.file.replace(/\.zip$/, "") + "/include");
+        core.exportVariable("LIBRARY_PATH", cachedPath + "/" + url.file.replace(/\.zip$/, "") + "/bin");
         core.exportVariable("Z3_SYS_Z3_HEADER", cachedPath + "/" + url.file.replace(/\.zip$/, "") + "/include/z3.h");
     } catch (error) {
         core.setFailed(error.message);

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function z3URL(architecture, version, distribution) {
     return { path: path, file: file };
 }
 
-(async function() {
+(async function () {
     try {
         const architecture = core.getInput('architecture', { required: true });
         const distribution = core.getInput('distribution', { required: true });
@@ -18,7 +18,8 @@ function z3URL(architecture, version, distribution) {
         const dir = await tc.extractZip(path)
         const cachedPath = await tc.cacheDir(dir, 'z3', version);
         core.addPath(cachedPath + "/" + url.file.replace(/\.zip$/, "") + "/bin");
-	core.exportVariable("CPATH", cachedPath + "/" + url.file.replace(/\.zip$/, "") + "/include");
+        core.exportVariable("CPATH", cachedPath + "/" + url.file.replace(/\.zip$/, "") + "/include");
+        core.exportVariable("Z3_SYS_Z3_HEADER", cachedPath + "/" + url.file.replace(/\.zip$/, "") + "/include/z3.h");
     } catch (error) {
         core.setFailed(error.message);
     }


### PR DESCRIPTION
The rust crate [z3](https://github.com/prove-rs/z3.rs) can use the env var `Z3_SYS_Z3_HEADER` (path to `z3.h`) to be built.
This build mode is much simpler on Windows. I hope you will accept this feature.

Then the export of `LIBRARY_PATH` is used to find the `libz3` library.

(I also formatted the code with prettier.)